### PR TITLE
Add CUDA sync to host_task & replace backend::cuda with backend::ext_oneeapi_cuda

### DIFF
--- a/examples/MPI/SYCL-MPI-Sample.cpp
+++ b/examples/MPI/SYCL-MPI-Sample.cpp
@@ -78,9 +78,9 @@ int main(int argc, char *argv[]) {
     sycl::accessor local_acc{local_buffer, h, sycl::read_write};
     h.host_task([=](sycl::interop_handle ih) {
       auto cuda_ptr = reinterpret_cast<double *>(
-          ih.get_native_mem<sycl::backend::cuda>(input_acc));
+          ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(input_acc));
       auto cuda_local_ptr = reinterpret_cast<double *>(
-          ih.get_native_mem<sycl::backend::cuda>(local_acc));
+          ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(local_acc));
       MPI_Scatter(cuda_ptr, local_size, MPI_DOUBLE, cuda_local_ptr, local_size,
                   MPI_DOUBLE, 0, MPI_COMM_WORLD);
     });
@@ -122,9 +122,9 @@ int main(int argc, char *argv[]) {
     sycl::accessor global_sum_acc{global_sum, h, sycl::read_write};
     h.host_task([=](sycl::interop_handle ih) {
       auto cuda_out_ptr = reinterpret_cast<double *>(
-          ih.get_native_mem<sycl::backend::cuda>(out_acc));
+          ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(out_acc));
       auto cuda_global_sum_ptr = reinterpret_cast<double *>(
-          ih.get_native_mem<sycl::backend::cuda>(global_sum_acc));
+          ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(global_sum_acc));
       MPI_Allreduce(cuda_out_ptr, cuda_global_sum_ptr, 1, MPI_DOUBLE, MPI_SUM,
                     MPI_COMM_WORLD);
     });
@@ -153,9 +153,9 @@ int main(int argc, char *argv[]) {
     sycl::accessor local_acc{local_buffer, h, sycl::read_write};
     h.host_task([=](sycl::interop_handle ih) {
       auto cuda_local_ptr = reinterpret_cast<double *>(
-          ih.get_native_mem<sycl::backend::cuda>(local_acc));
+          ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(local_acc));
       auto cuda_input_ptr = reinterpret_cast<double *>(
-          ih.get_native_mem<sycl::backend::cuda>(input_acc));
+          ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(input_acc));
       MPI_Gather(cuda_local_ptr, local_size, MPI_DOUBLE, cuda_input_ptr,
                  local_size, MPI_DOUBLE, 0, MPI_COMM_WORLD);
     });

--- a/examples/cuda_interop/vec_add.cu
+++ b/examples/cuda_interop/vec_add.cu
@@ -74,6 +74,9 @@ int main(int argc, char *argv[]) {
         gridSize = static_cast<int>(ceil(static_cast<float>(n) / blockSize));
         // Call the CUDA kernel directly from SYCL
         vecAdd<<<gridSize, blockSize>>>(dA, dB, dC, n);
+        // Interop with host_task doesn't add CUDA event to task graph
+        // so we must manually sync here.
+        cudaDeviceSynchronize();
       });
     });
 

--- a/examples/cuda_interop/vec_add.cu
+++ b/examples/cuda_interop/vec_add.cu
@@ -11,7 +11,7 @@
 class CUDASelector : public sycl::device_selector {
 public:
   int operator()(const sycl::device &device) const override {
-    if(device.get_platform().get_backend() == sycl::backend::cuda){
+    if(device.get_platform().get_backend() == sycl::backend::ext_oneapi_cuda){
       std::cout << " CUDA device found " << std::endl;
       return 1;
     } else{
@@ -63,9 +63,9 @@ int main(int argc, char *argv[]) {
       auto accC = bC.get_access<access::mode::write>(h);
 
       h.host_task([=](interop_handle ih) {
-        auto dA = reinterpret_cast<double*>(ih.get_native_mem<backend::cuda>(accA));
-        auto dB = reinterpret_cast<double*>(ih.get_native_mem<backend::cuda>(accB));
-        auto dC = reinterpret_cast<double*>(ih.get_native_mem<backend::cuda>(accC));
+        auto dA = reinterpret_cast<double*>(ih.get_native_mem<backend::ext_oneapi_cuda>(accA));
+        auto dB = reinterpret_cast<double*>(ih.get_native_mem<backend::ext_oneapi_cuda>(accB));
+        auto dC = reinterpret_cast<double*>(ih.get_native_mem<backend::ext_oneapi_cuda>(accC));
 
         int blockSize, gridSize;
         // Number of threads in each thread block

--- a/examples/cuda_interop/vec_add_usm.cu
+++ b/examples/cuda_interop/vec_add_usm.cu
@@ -7,7 +7,7 @@
 class CUDASelector : public sycl::device_selector {
 public:
   int operator()(const sycl::device &device) const override {
-    if(device.get_platform().get_backend() == sycl::backend::cuda){
+    if(device.get_platform().get_backend() == sycl::backend::ext_oneapi_cuda){
       std::cout << " CUDA device found " << std::endl;
       return 1;
     } else{

--- a/examples/distrib_batch_gemm/distributed-batch-gemm.cpp
+++ b/examples/distrib_batch_gemm/distributed-batch-gemm.cpp
@@ -99,9 +99,9 @@ int main(int argc, char **argv) {
             h);
     h.interop_task([=](sycl::interop_handle ih) {
       auto global_a_ptr = reinterpret_cast<float *>(
-          ih.get_native_mem<sycl::backend::cuda>(global_a_acc));
+          ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(global_a_acc));
       auto local_a_ptr = reinterpret_cast<float *>(
-          ih.get_native_mem<sycl::backend::cuda>(local_a_acc));
+          ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(local_a_acc));
       MPI_Scatter(global_a_ptr, lda * k, MPI_FLOAT, local_a_ptr, lda * k,
                   MPI_FLOAT, 0, MPI_COMM_WORLD);
     });
@@ -117,9 +117,9 @@ int main(int argc, char **argv) {
             h);
     h.interop_task([=](sycl::interop_handle ih) {
       auto global_b_ptr = reinterpret_cast<float *>(
-          ih.get_native_mem<sycl::backend::cuda>(global_b_acc));
+          ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(global_b_acc));
       auto local_b_ptr = reinterpret_cast<float *>(
-          ih.get_native_mem<sycl::backend::cuda>(local_b_acc));
+          ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(local_b_acc));
       MPI_Scatter(global_b_ptr, ldb * n, MPI_FLOAT, local_b_ptr, ldb * n,
                   MPI_FLOAT, 0, MPI_COMM_WORLD);
     });
@@ -144,9 +144,9 @@ int main(int argc, char **argv) {
             h);
     h.interop_task([=](sycl::interop_handle ih) {
       auto local_c_ptr = reinterpret_cast<float *>(
-          ih.get_native_mem<sycl::backend::cuda>(local_c_acc));
+          ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(local_c_acc));
       auto global_c_ptr = reinterpret_cast<float *>(
-          ih.get_native_mem<sycl::backend::cuda>(global_c_acc));
+          ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(global_c_acc));
       MPI_Gather(local_c_ptr, ldc * n, MPI_FLOAT, global_c_ptr, ldc * n,
                  MPI_FLOAT, 0, MPI_COMM_WORLD);
     });

--- a/examples/hashing/include/tools/sycl_queue_helpers.hpp
+++ b/examples/hashing/include/tools/sycl_queue_helpers.hpp
@@ -18,7 +18,7 @@ class cuda_selector : public sycl::device_selector {
 public:
     int operator()(const sycl::device &device) const override {
 #if defined(SYCL_IMPLEMENTATION_ONEAPI) || defined(SYCL_IMPLEMENTATION_INTEL)
-        return device.get_platform().get_backend() == sycl::backend::cuda && device.get_info<sycl::info::device::is_available>() ? 1 : -1;
+        return device.get_platform().get_backend() == sycl::backend::ext_oneapi_cuda && device.get_info<sycl::info::device::is_available>() ? 1 : -1;
 #else
         return device.is_gpu() && (device.get_info<sycl::info::device::name>().find("NVIDIA") != std::string::npos) ? 1 : -1;
 #endif

--- a/examples/sgemm_interop/sycl_sgemm.cpp
+++ b/examples/sgemm_interop/sycl_sgemm.cpp
@@ -81,6 +81,8 @@ int main() {
       auto d_C = b_C.get_access<sycl::access::mode::write>(h);
 
       h.host_task([=](sycl::interop_handle ih) {
+        auto cuStream = ih.get_native_queue<backend::ext_oneapi_cuda>();
+        cublasSetStream(handle, cuStream);
         cuCtxSetCurrent(ih.get_native_context<backend::cuda>());
         cublasSetStream(handle, ih.get_native_queue<backend::cuda>());
         auto cuA = reinterpret_cast<float *>(ih.get_native_mem<backend::cuda>(d_A));
@@ -90,6 +92,7 @@ int main() {
         CHECK_ERROR(cublasSgemm(handle, CUBLAS_OP_N, CUBLAS_OP_N, WIDTH, HEIGHT,
                                 WIDTH, &ALPHA, cuA, WIDTH, cuB, WIDTH, &BETA,
                                 cuC, WIDTH));
+        cuStreamSynchronize(cuStream);
       });
     });
   }

--- a/examples/sgemm_interop/sycl_sgemm.cpp
+++ b/examples/sgemm_interop/sycl_sgemm.cpp
@@ -34,7 +34,7 @@ void inline checkCudaErrorMsg(CUresult status, const char *msg) {
 class CUDASelector : public sycl::device_selector {
 public:
   int operator()(const sycl::device &device) const override {
-    if(device.get_platform().get_backend() == sycl::backend::cuda){
+    if(device.get_platform().get_backend() == sycl::backend::ext_oneapi_cuda){
       std::cout << " CUDA device found " << std::endl;
       return 1;
     } else{
@@ -81,13 +81,12 @@ int main() {
       auto d_C = b_C.get_access<sycl::access::mode::write>(h);
 
       h.host_task([=](sycl::interop_handle ih) {
+        cuCtxSetCurrent(ih.get_native_context<backend::ext_oneapi_cuda>());
         auto cuStream = ih.get_native_queue<backend::ext_oneapi_cuda>();
         cublasSetStream(handle, cuStream);
-        cuCtxSetCurrent(ih.get_native_context<backend::cuda>());
-        cublasSetStream(handle, ih.get_native_queue<backend::cuda>());
-        auto cuA = reinterpret_cast<float *>(ih.get_native_mem<backend::cuda>(d_A));
-        auto cuB = reinterpret_cast<float *>(ih.get_native_mem<backend::cuda>(d_B));
-        auto cuC = reinterpret_cast<float *>(ih.get_native_mem<backend::cuda>(d_C));
+        auto cuA = reinterpret_cast<float *>(ih.get_native_mem<backend::ext_oneapi_cuda>(d_A));
+        auto cuB = reinterpret_cast<float *>(ih.get_native_mem<backend::ext_oneapi_cuda>(d_B));
+        auto cuC = reinterpret_cast<float *>(ih.get_native_mem<backend::ext_oneapi_cuda>(d_C));
 
         CHECK_ERROR(cublasSgemm(handle, CUBLAS_OP_N, CUBLAS_OP_N, WIDTH, HEIGHT,
                                 WIDTH, &ALPHA, cuA, WIDTH, cuB, WIDTH, &BETA,

--- a/examples/sgemm_interop/sycl_sgemm_usm.cpp
+++ b/examples/sgemm_interop/sycl_sgemm_usm.cpp
@@ -34,7 +34,7 @@ void inline checkCudaErrorMsg(CUresult status, const char *msg) {
 class CUDASelector : public sycl::device_selector {
 public:
   int operator()(const sycl::device &device) const override {
-    if(device.get_platform().get_backend() == sycl::backend::cuda){
+    if(device.get_platform().get_backend() == sycl::backend::ext_oneapi_cuda){
       std::cout << " CUDA device found " << std::endl;
       return 1;
     } else{
@@ -86,6 +86,7 @@ int main() {
     h.host_task([=](sycl::interop_handle ih) {
 
       // Set the correct cuda context & stream
+      cuCtxSetCurrent(ih.get_native_context<backend::ext_oneapi_cuda>());
       auto cuStream = ih.get_native_queue<backend::ext_oneapi_cuda>();
       cublasSetStream(handle, cuStream);
 

--- a/examples/sgemm_interop/sycl_sgemm_usm.cpp
+++ b/examples/sgemm_interop/sycl_sgemm_usm.cpp
@@ -86,13 +86,14 @@ int main() {
     h.host_task([=](sycl::interop_handle ih) {
 
       // Set the correct cuda context & stream
-      cuCtxSetCurrent(ih.get_native_context<backend::cuda>());
-      cublasSetStream(handle, ih.get_native_queue<backend::cuda>());
+      auto cuStream = ih.get_native_queue<backend::ext_oneapi_cuda>();
+      cublasSetStream(handle, cuStream);
 
       // Call generalised matrix-matrix multiply
       CHECK_ERROR(cublasSgemm(handle, CUBLAS_OP_N, CUBLAS_OP_N, WIDTH, HEIGHT,
                               WIDTH, &ALPHA, d_A, WIDTH, d_B, WIDTH, &BETA,
                               d_C, WIDTH));
+      cuStreamSynchronize(cuStream);
     });
   }).wait();
 

--- a/examples/vector_addition/vector_addition.cpp
+++ b/examples/vector_addition/vector_addition.cpp
@@ -27,7 +27,7 @@
 class CUDASelector : public sycl::device_selector {
 public:
   int operator()(const sycl::device &device) const override {
-    if(device.get_platform().get_backend() == sycl::backend::cuda){
+    if(device.get_platform().get_backend() == sycl::backend::ext_oneapi_cuda){
       std::cout << " CUDA device found " << std::endl;
       return 1;
     } else{

--- a/examples/vector_addition/vector_addition_usm.cpp
+++ b/examples/vector_addition/vector_addition_usm.cpp
@@ -27,7 +27,7 @@
 class CUDASelector : public sycl::device_selector {
 public:
   int operator()(const sycl::device &device) const override {
-    if(device.get_platform().get_backend() == sycl::backend::cuda){
+    if(device.get_platform().get_backend() == sycl::backend::ext_oneapi_cuda){
       std::cout << " CUDA device found " << std::endl;
       return 1;
     } else{

--- a/setup-script/README.md
+++ b/setup-script/README.md
@@ -29,7 +29,7 @@ config file.
 class CUDADeviceSelector : public sycl::device_selector {
 public:
     int operator()(const sycl::device &device) const override {
-        return device.get_platform().get_backend() == sycl::backend::cuda ? 1 : -1;
+        return device.get_platform().get_backend() == sycl::backend::ext_oneapi_cuda ? 1 : -1;
     }
 };
 ```

--- a/setup-script/sample/include/common.hpp
+++ b/setup-script/sample/include/common.hpp
@@ -11,7 +11,7 @@ using namespace usm_smart_ptr;
 class cuda_selector : public sycl::device_selector {
 public:
     int operator()(const sycl::device &device) const override {
-        return device.get_platform().get_backend() == sycl::backend::cuda;
+        return device.get_platform().get_backend() == sycl::backend::ext_oneapi_cuda;
         //return device.is_gpu() && (device.get_info<sycl::info::device::driver_version>().find("CUDA") != std::string::npos);
     }
 };


### PR DESCRIPTION
Explicit CUDA synchronization is necessary now because of changes to implementation of `host_task`. Technically, according to the spec, this should always have been necessary.

I've also addressed some deprecation warnings associated with `sycl::backend::cuda`.