### PR TITLE
Adding Kokkos test case

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ This demonstrates using SYCL's `host_task` for CUDA interoperability, calling CU
 
 This example combines the MPI and SGEMM Interop examples to distribute a matrix multiplication problem between MPI ranks.
 
+[Kokkos](examples/kokkos)
+--------------------------------------------
+
+[Kokkos](https://github.com/kokkos/kokkos) is a middle-layer for scientific computing which features a SYCL backend. This example 
+shows a small Kokkos test case (vector-matrix-vector multiplication), adapted from a test case in the Kokkos repo; 
+there is no SYCL code in the example, but it includes scripts to build Kokkos with SYCL support.
+
 [Hashing Algorithms](examples/hashing)
 --------------------------------------------
 

--- a/examples/kokkos/CMakeLists.txt
+++ b/examples/kokkos/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required (VERSION 3.10)
+cmake_policy(SET CMP0074 NEW)
+project (Kokkos_Test_Case)
+
+set(Kokkos_DIR "$ENV{Kokkos_ROOT}" CACHE STRING "Kokkos root directory")
+find_package(Kokkos REQUIRED)
+
+add_executable(test_case test_case.cpp)
+target_link_libraries(test_case Kokkos::kokkos)
+
+

--- a/examples/kokkos/README.md
+++ b/examples/kokkos/README.md
@@ -1,0 +1,39 @@
+Simple Test Case for Kokkos
+----
+
+This is a simple standalone test case taken from the Kokkos repository & packaged up here for use with SYCL.
+It's doing a vector-matrix-vector product. It's an identity matrix with two vectors of 1s, so the expected answer
+is just equal to the problem size.
+
+Building the test case
+-----
+
+test_case.cpp contains a simple kernel which has been copied straight from the Kokkos Tutorials (Exercises/02/Solution).
+
+Build it with build.sh
+
+Running the test case
+----
+
+Just launch it! There are optional flags:
+
+-N : number of rows
+-M : number of columns
+-S : total size
+-nrepeat : how many times to repeat the test (default 100)
+
+Obviously, not all of N, M & S should be set. The test case will sanity check your args anyway.
+
+Building kokkos
+------
+
+In case you don't have an existing Kokkos build, there are some build scripts in `./kokkos_build_scripts`.
+There are scripts for building Kokkos with SYCL, or CUDA (nvcc or clang).
+
+Modify KOKKOS_ROOT for your environment.
+There's also a 'module load' for ompi, though obviously you could just set environment variables.
+
+Otherwise this script largely imitates the Kokkos portion of our full installation script.
+
+
+

--- a/examples/kokkos/README.md
+++ b/examples/kokkos/README.md
@@ -27,7 +27,7 @@ Just launch it! There are optional flags:
 
 Obviously, not all of N, M & S should be set. The test case will sanity check your args anyway.
 
-Building kokkos
+Building Kokkos
 ------
 
 In case you don't have an existing Kokkos build, there are some build scripts in `./kokkos_build_scripts`.
@@ -39,13 +39,22 @@ KOKKOS_INSTALL_DIR=[/your/install/dir]
 KOKKOS_SOURCE_DIR=[/your/source/dir]
 HWLOC_DIR=[/your/hwloc/dir]
 ```
-**Note**: if you do not have a HWLOC installation, this option can be removed & Kokkos will be built without HWLOC support.
 
-You should modify the cmake command for your GPU arch. The current value:
+HWLOC
+------
+
+The [Portable Hardware Locality](https://www.open-mpi.org/projects/hwloc/) (hwloc) package is an optional dependency which enables Kokkos to query the hardware topology of the system on which it is running. If you do not have a HWLOC installation, this option can be removed & Kokkos will be built without HWLOC support.
+
+SYCL backend
+-------------
+
+Kokkos should work with any SYCL backend, though the focus of this examples repo is SYCL-For-CUDA.
+Previous work at Codeplay has involved running Kokkos with SYCL on Nvidia hardware with Ampere architecture, hence the flag:
 ```
       -DKokkos_ARCH_AMPERE80=ON \
 ```
-represents CUDA's Ampere architecture (SM_80).
+This flag is not strictly necessary, but it enables Ahead of Time (AoT) compilation, which can give a significant performance gain when building large projects built on Kokkos.
+You should modify the cmake command for your GPU arch.
 
 
 

--- a/examples/kokkos/README.md
+++ b/examples/kokkos/README.md
@@ -10,7 +10,10 @@ Building the test case
 
 test_case.cpp contains a simple kernel which has been copied straight from the Kokkos Tutorials (Exercises/02/Solution).
 
-Build it with build.sh
+Build it with build.sh, after setting the environment variable:
+```
+Kokkos_ROOT="[your/kokkos/installation]/lib/cmake/Kokkos"
+```
 
 Running the test case
 ----
@@ -30,10 +33,19 @@ Building kokkos
 In case you don't have an existing Kokkos build, there are some build scripts in `./kokkos_build_scripts`.
 There are scripts for building Kokkos with SYCL, or CUDA (nvcc or clang).
 
-Modify KOKKOS_ROOT for your environment.
-There's also a 'module load' for ompi, though obviously you could just set environment variables.
+Set the following environment variables:
+```
+KOKKOS_INSTALL_DIR=[/your/install/dir]
+KOKKOS_SOURCE_DIR=[/your/source/dir]
+HWLOC_DIR=[/your/hwloc/dir]
+```
+**Note**: if you do not have a HWLOC installation, this option can be removed & Kokkos will be built without HWLOC support.
 
-Otherwise this script largely imitates the Kokkos portion of our full installation script.
+You should modify the cmake command for your GPU arch. The current value:
+```
+      -DKokkos_ARCH_AMPERE80=ON \
+```
+represents CUDA's Ampere architecture (SM_80).
 
 
 

--- a/examples/kokkos/build.sh
+++ b/examples/kokkos/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+rm -rf build
+mkdir build
+cd build
+
+Kokkos_ROOT="$HOME/soft/kokkos/kokkos_install/lib/cmake/Kokkos" \
+CXXFLAGS="-Xsycl-target-frontend -O3" \
+LDFLAGS="-Xsycl-target-frontend -O3" \
+cmake .. -G Ninja \
+      -DCMAKE_BUILD_TYPE=Debug \
+      -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+      -DCMAKE_CXX_COMPILER=clang++ \
+      -DCMAKE_C_COMPILER=clang
+
+ninja
+
+cd ..

--- a/examples/kokkos/build.sh
+++ b/examples/kokkos/build.sh
@@ -4,7 +4,7 @@ rm -rf build
 mkdir build
 cd build
 
-Kokkos_ROOT="$HOME/soft/kokkos/kokkos_install/lib/cmake/Kokkos" \
+# Set the environment variable Kokkos_ROOT="[your/kokkos/installation]/lib/cmake/Kokkos"
 CXXFLAGS="-Xsycl-target-frontend -O3" \
 LDFLAGS="-Xsycl-target-frontend -O3" \
 cmake .. -G Ninja \

--- a/examples/kokkos/kokkos_build_scripts/README.md
+++ b/examples/kokkos/kokkos_build_scripts/README.md
@@ -1,0 +1,1 @@
+These build scripts are provided for illustration only. They will almost certainly require modification before they work elsewhere.

--- a/examples/kokkos/kokkos_build_scripts/kokkos_build.sh
+++ b/examples/kokkos/kokkos_build_scripts/kokkos_build.sh
@@ -3,10 +3,10 @@
 
 set -x #echo on
 
-module load ompi
-
-KOKKOS_ROOT=$HOME/soft/kokkos
-KOKKOS_SOURCE_DIR=$HOME/sources/kokkos
+# Set:
+# KOKKOS_INSTALL_DIR=[/your/install/dir]
+# KOKKOS_SOURCE_DIR=[/your/source/dir]
+# HWLOC_DIR=[/your/hwloc/dir]
 
 # Configure & build kokkos
 mkdir kokkos-build
@@ -18,7 +18,7 @@ cmake $KOKKOS_SOURCE_DIR -G Ninja \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_CXX_STANDARD=17 \
       -DCMAKE_CXX_COMPILER=clang++ \
-      -DCMAKE_INSTALL_PREFIX=$KOKKOS_ROOT/kokkos_install \
+      -DCMAKE_INSTALL_PREFIX=$KOKKOS_INSTALL_DIR \
       -DKokkos_CXX_STANDARD=17 \
       -DKokkos_ENABLE_SYCL=ON \
       -DKokkos_ARCH_HSW=ON \
@@ -26,7 +26,7 @@ cmake $KOKKOS_SOURCE_DIR -G Ninja \
       -DKokkos_ENABLE_HWLOC=ON \
       -DKokkos_ENABLE_UNSUPPORTED_ARCHS=ON \
       -DKokkos_ENABLE_TESTS=OFF \
-      -DKokkos_HWLOC_DIR=$HOME/soft/ompi
+      -DKokkos_HWLOC_DIR=$HWLOC_DIR
 
 ninja install
 

--- a/examples/kokkos/kokkos_build_scripts/kokkos_build.sh
+++ b/examples/kokkos/kokkos_build_scripts/kokkos_build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Install Kokkos w/ sycl-cuda support
+
+set -x #echo on
+
+module load ompi
+
+KOKKOS_ROOT=$HOME/soft/kokkos
+KOKKOS_SOURCE_DIR=$HOME/sources/kokkos
+
+# Configure & build kokkos
+mkdir kokkos-build
+cd kokkos-build
+
+CXXFLAGS="-Xsycl-target-frontend -O3 -fgpu-inline-threshold=100000 -Wno-unknown-cuda-version -Wno-deprecated-declarations -Wno-linker-warnings -ffast-math" \
+LDFLAGS="-Xsycl-target-frontend -O3" \
+cmake $KOKKOS_SOURCE_DIR -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_CXX_STANDARD=17 \
+      -DCMAKE_CXX_COMPILER=clang++ \
+      -DCMAKE_INSTALL_PREFIX=$KOKKOS_ROOT/kokkos_install \
+      -DKokkos_CXX_STANDARD=17 \
+      -DKokkos_ENABLE_SYCL=ON \
+      -DKokkos_ARCH_HSW=ON \
+      -DKokkos_ARCH_AMPERE80=ON \
+      -DKokkos_ENABLE_HWLOC=ON \
+      -DKokkos_ENABLE_UNSUPPORTED_ARCHS=ON \
+      -DKokkos_ENABLE_TESTS=OFF \
+      -DKokkos_HWLOC_DIR=$HOME/soft/ompi
+
+ninja install
+
+cd ..

--- a/examples/kokkos/kokkos_build_scripts/kokkos_clang_cuda_build.sh
+++ b/examples/kokkos/kokkos_build_scripts/kokkos_clang_cuda_build.sh
@@ -3,10 +3,10 @@
 
 set -x #echo on
 
-module load ompi
-
-KOKKOS_ROOT=$HOME/Kokkos
-KOKKOS_SOURCE_DIR=$KOKKOS_ROOT/kokkos
+# Set:
+# KOKKOS_INSTALL_DIR=[/your/install/dir]
+# KOKKOS_SOURCE_DIR=[/your/source/dir]
+# HWLOC_DIR=[/your/hwloc/dir]
 
 # Configure & build kokkos
 mkdir kokkos-build
@@ -18,7 +18,7 @@ cmake $KOKKOS_SOURCE_DIR -G Ninja \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_CXX_STANDARD=17 \
       -DCMAKE_CXX_COMPILER=clang++ \
-      -DCMAKE_INSTALL_PREFIX=$KOKKOS_ROOT/kokkos_clang_cuda_install \
+      -DCMAKE_INSTALL_PREFIX=$KOKKOS_INSTALL_DIR \
       -DKokkos_CXX_STANDARD=17 \
       -DKokkos_ENABLE_SYCL=OFF \
       -DKokkos_ENABLE_CUDA=ON \
@@ -27,7 +27,7 @@ cmake $KOKKOS_SOURCE_DIR -G Ninja \
       -DKokkos_ENABLE_HWLOC=ON \
       -DKokkos_ENABLE_UNSUPPORTED_ARCHS=ON \
       -DKokkos_ENABLE_TESTS=OFF \
-      -DKokkos_HWLOC_DIR=$HOME/soft/ompi
+      -DKokkos_HWLOC_DIR=$HWLOC_DIR
 
 ninja install
 

--- a/examples/kokkos/kokkos_build_scripts/kokkos_clang_cuda_build.sh
+++ b/examples/kokkos/kokkos_build_scripts/kokkos_clang_cuda_build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Install Kokkos w/ sycl-cuda support
+
+set -x #echo on
+
+module load ompi
+
+KOKKOS_ROOT=$HOME/Kokkos
+KOKKOS_SOURCE_DIR=$KOKKOS_ROOT/kokkos
+
+# Configure & build kokkos
+mkdir kokkos-build
+cd kokkos-build
+
+CXXFLAGS="-Xsycl-target-frontend -O3 -fgpu-inline-threshold=100000" \
+LDFLAGS="-Xsycl-target-frontend -O3" \
+cmake $KOKKOS_SOURCE_DIR -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_CXX_STANDARD=17 \
+      -DCMAKE_CXX_COMPILER=clang++ \
+      -DCMAKE_INSTALL_PREFIX=$KOKKOS_ROOT/kokkos_clang_cuda_install \
+      -DKokkos_CXX_STANDARD=17 \
+      -DKokkos_ENABLE_SYCL=OFF \
+      -DKokkos_ENABLE_CUDA=ON \
+      -DKokkos_ARCH_HSW=ON \
+      -DKokkos_ARCH_AMPERE80=ON \
+      -DKokkos_ENABLE_HWLOC=ON \
+      -DKokkos_ENABLE_UNSUPPORTED_ARCHS=ON \
+      -DKokkos_ENABLE_TESTS=OFF \
+      -DKokkos_HWLOC_DIR=$HOME/soft/ompi
+
+ninja install
+
+cd ..

--- a/examples/kokkos/kokkos_build_scripts/kokkos_nvcc_cuda_build.sh
+++ b/examples/kokkos/kokkos_build_scripts/kokkos_nvcc_cuda_build.sh
@@ -3,23 +3,21 @@
 
 set -x #echo on
 
-module load ompi
-
-KOKKOS_ROOT=$HOME/Kokkos
-KOKKOS_SOURCE_DIR=$KOKKOS_ROOT/kokkos
+# Set:
+# KOKKOS_INSTALL_DIR=[/your/install/dir]
+# KOKKOS_SOURCE_DIR=[/your/source/dir]
+# HWLOC_DIR=[/your/hwloc/dir]
 
 # Configure & build kokkos
 mkdir kokkos-build
 cd kokkos-build
 
-# CXXFLAGS="-Xsycl-target-frontend -O3" \
-# LDFLAGS="-Xsycl-target-frontend -O3" \
 cmake $KOKKOS_SOURCE_DIR -G Ninja \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_CXX_STANDARD=17 \
       -DCMAKE_CXX_COMPILER=g++ \
       -DCMAKE_CUDA_COMPILER=nvcc \
-      -DCMAKE_INSTALL_PREFIX=$KOKKOS_ROOT/kokkos_nvcc_cuda_install \
+      -DCMAKE_INSTALL_PREFIX=$KOKKOS_INSTALL_DIR \
       -DKokkos_CXX_STANDARD=17 \
       -DKokkos_ENABLE_SYCL=OFF \
       -DKokkos_ENABLE_CUDA=ON \
@@ -28,7 +26,7 @@ cmake $KOKKOS_SOURCE_DIR -G Ninja \
       -DKokkos_ENABLE_HWLOC=ON \
       -DKokkos_ENABLE_UNSUPPORTED_ARCHS=ON \
       -DKokkos_ENABLE_TESTS=OFF \
-      -DKokkos_HWLOC_DIR=$HOME/soft/ompi
+      -DKokkos_HWLOC_DIR=$HWLOC_DIR
 
 ninja install
 

--- a/examples/kokkos/kokkos_build_scripts/kokkos_nvcc_cuda_build.sh
+++ b/examples/kokkos/kokkos_build_scripts/kokkos_nvcc_cuda_build.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Install Kokkos w/ sycl-cuda support
+
+set -x #echo on
+
+module load ompi
+
+KOKKOS_ROOT=$HOME/Kokkos
+KOKKOS_SOURCE_DIR=$KOKKOS_ROOT/kokkos
+
+# Configure & build kokkos
+mkdir kokkos-build
+cd kokkos-build
+
+# CXXFLAGS="-Xsycl-target-frontend -O3" \
+# LDFLAGS="-Xsycl-target-frontend -O3" \
+cmake $KOKKOS_SOURCE_DIR -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_CXX_STANDARD=17 \
+      -DCMAKE_CXX_COMPILER=g++ \
+      -DCMAKE_CUDA_COMPILER=nvcc \
+      -DCMAKE_INSTALL_PREFIX=$KOKKOS_ROOT/kokkos_nvcc_cuda_install \
+      -DKokkos_CXX_STANDARD=17 \
+      -DKokkos_ENABLE_SYCL=OFF \
+      -DKokkos_ENABLE_CUDA=ON \
+      -DKokkos_ARCH_HSW=ON \
+      -DKokkos_ARCH_AMPERE80=ON \
+      -DKokkos_ENABLE_HWLOC=ON \
+      -DKokkos_ENABLE_UNSUPPORTED_ARCHS=ON \
+      -DKokkos_ENABLE_TESTS=OFF \
+      -DKokkos_HWLOC_DIR=$HOME/soft/ompi
+
+ninja install
+
+cd ..

--- a/examples/kokkos/test_case.cpp
+++ b/examples/kokkos/test_case.cpp
@@ -1,0 +1,218 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions Contact  H. Carter Edwards (hcedwar@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <limits>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <sys/time.h>
+
+#include <Kokkos_Core.hpp>
+#include <Kokkos_DualView.hpp>
+// #include <Kokkos_SYCL.hpp>
+
+void checkSizes( int &N, int &M, int &S, int &nrepeat );
+
+int main( int argc, char* argv[] )
+{
+  int N = -1;         // number of rows 2^12
+  int M = -1;         // number of columns 2^10
+  int S = -1;         // total size 2^22
+  int nrepeat = 100;  // number of repeats of the test
+
+  // Read command line arguments.
+  for ( int i = 0; i < argc; i++ ) {
+    if ( ( strcmp( argv[ i ], "-N" ) == 0 ) || ( strcmp( argv[ i ], "-Rows" ) == 0 ) ) {
+      N = pow( 2, atoi( argv[ ++i ] ) );
+      printf( "  User N is %d\n", N );
+    }
+    else if ( ( strcmp( argv[ i ], "-M" ) == 0 ) || ( strcmp( argv[ i ], "-Columns" ) == 0 ) ) {
+      M = pow( 2, atof( argv[ ++i ] ) );
+      printf( "  User M is %d\n", M );
+    }
+    else if ( ( strcmp( argv[ i ], "-S" ) == 0 ) || ( strcmp( argv[ i ], "-Size" ) == 0 ) ) {
+      S = pow( 2, atof( argv[ ++i ] ) );
+      printf( "  User S is %d\n", S );
+    }
+    else if ( strcmp( argv[ i ], "-nrepeat" ) == 0 ) {
+      nrepeat = atoi( argv[ ++i ] );
+    }
+    else if ( ( strcmp( argv[ i ], "-h" ) == 0 ) || ( strcmp( argv[ i ], "-help" ) == 0 ) ) {
+      printf( "  y^T*A*x Options:\n" );
+      printf( "  -Rows (-N) <int>:      exponent num, determines number of rows 2^num (default: 2^12 = 4096)\n" );
+      printf( "  -Columns (-M) <int>:   exponent num, determines number of columns 2^num (default: 2^10 = 1024)\n" );
+      printf( "  -Size (-S) <int>:      exponent num, determines total matrix size 2^num (default: 2^22 = 4096*1024 )\n" );
+      printf( "  -nrepeat <int>:        number of repetitions (default: 100)\n" );
+      printf( "  -help (-h):            print this message\n\n" );
+      exit( 1 );
+    }
+  }
+
+  // Check sizes.
+  checkSizes( N, M, S, nrepeat );
+
+  Kokkos::initialize( argc, argv );
+  {
+
+  // Allocate y, x vectors and Matrix A on device.
+  typedef Kokkos::DualView<double*>   ViewVectorType;
+  typedef Kokkos::DualView<double**>  ViewMatrixType;
+  ViewVectorType y( "y", N );
+  ViewVectorType x( "x", M );
+  ViewMatrixType A( "A", N, M );
+
+  // Initialize y vector on host.
+  for ( int i = 0; i < N; ++i ) {
+    y.h_view( i ) = 1;
+  }
+
+  // Initialize x vector on host.
+  for ( int i = 0; i < M; ++i ) {
+    x.h_view( i ) = 1;
+  }
+
+  // Initialize A matrix on host, note 2D indexing.
+  for ( int j = 0; j < N; ++j ) {
+    for ( int i = 0; i < M; ++i ) {
+      A.h_view( j, i ) = 1;
+    }
+  }
+
+  y.template modify<typename ViewVectorType::host_mirror_space>();
+  x.template modify<typename ViewVectorType::host_mirror_space>();
+  A.template modify<typename ViewMatrixType::host_mirror_space>();
+
+  y.template sync<typename ViewVectorType::execution_space>();
+  x.template sync<typename ViewVectorType::execution_space>();
+  A.template sync<typename ViewMatrixType::execution_space>();
+
+  // Timer products.
+  Kokkos::Timer timer;
+
+  for ( int repeat = 0; repeat < nrepeat; repeat++ ) {
+    // Application: <y,Ax> = y^T*A*x
+    double result = 0;
+
+    Kokkos::parallel_reduce( "yAx", N, KOKKOS_LAMBDA ( int j, double &update ) {
+      double temp2 = 0;
+
+      for ( int i = 0; i < M; ++i ) {
+        temp2 += A.d_view( j, i ) * x.d_view( i );
+      }
+
+      update += y.d_view( j ) * temp2;
+    }, result );
+
+    // Output result.
+    if ( repeat == ( nrepeat - 1 ) ) {
+      printf( "  Computed result for %d x %d is %lf\n", N, M, result );
+    }
+
+    // All 1s, so the answer is just the size of the problem
+    const double solution = static_cast<float>(S);
+
+    if ( result != solution ) {
+      printf( "  Error: result( %lf ) != solution( %lf )\n", result, solution );
+    }
+  }
+
+  // Calculate time.
+  double time = timer.seconds();
+
+  // Calculate bandwidth.
+  // Each matrix A row (each of length M) is read once.
+  // The x vector (of length M) is read N times.
+  // The y vector (of length N) is read once.
+  // double Gbytes = 1.0e-9 * double( sizeof(double) * ( 2 * M * N + N ) );
+  double Gbytes = 1.0e-9 * double( sizeof(double) * ( M + M * N + N ) );
+
+  // Print results (problem size, time and bandwidth in GB/s).
+  printf( "  N( %d ) M( %d ) nrepeat ( %d ) problem( %g MB ) time( %g s ) bandwidth( %g GB/s )\n",
+          N, M, nrepeat, Gbytes * 1000, time, Gbytes * nrepeat / time );
+
+  }
+  Kokkos::finalize();
+
+  return 0;
+}
+
+void checkSizes( int &N, int &M, int &S, int &nrepeat ) {
+  // If S is undefined and N or M is undefined, set S to 2^22 or the bigger of N and M.
+  if ( S == -1 && ( N == -1 || M == -1 ) ) {
+    S = pow( 2, 22 );
+    if ( S < N ) S = N;
+    if ( S < M ) S = M;
+  }
+
+  // If S is undefined and both N and M are defined, set S = N * M.
+  if ( S == -1 ) S = N * M;
+
+  // If both N and M are undefined, fix row length to the smaller of S and 2^10 = 1024.
+  if ( N == -1 && M == -1 ) {
+    if ( S > 1024 ) {
+      M = 1024;
+    }
+    else {
+      M = S;
+    }
+  }
+
+  // If only M is undefined, set it.
+  if ( M == -1 ) M = S / N;
+
+  // If N is undefined, set it.
+  if ( N == -1 ) N = S / M;
+
+  printf( "  Total size S = %d N = %d M = %d\n", S, N, M );
+
+  // Check sizes.
+  if ( ( S < 0 ) || ( N < 0 ) || ( M < 0 ) || ( nrepeat < 0 ) ) {
+    printf( "  Sizes must be greater than 0.\n" );
+    exit( 1 );
+  }
+
+  if ( ( N * M ) != S ) {
+    printf( "  N * M != S\n" );
+    exit( 1 );
+  }
+}


### PR DESCRIPTION
This example actually has no SYCL code, it's just a demonstration of how to setup & use Kokkos with the SYCL backend.

In addition to the test case, there are several build scripts for building Kokkos with the SYCL-for-CUDA backend, plain SYCL backend, and the CUDA backend. 