### PR TITLE
Update vector_addition for new device selector

### DIFF
--- a/examples/vector_addition/vector_addition.cpp
+++ b/examples/vector_addition/vector_addition.cpp
@@ -24,17 +24,14 @@
 
 #include <CL/sycl.hpp>
 
-class CUDASelector : public sycl::device_selector {
-public:
-  int operator()(const sycl::device &device) const override {
-    if(device.get_platform().get_backend() == sycl::backend::ext_oneapi_cuda){
+int CUDASelector(sycl::device const & dev){
+  if(dev.get_platform().get_backend() == sycl::backend::ext_oneapi_cuda){
       std::cout << " CUDA device found " << std::endl;
       return 1;
     } else{
       return -1;
     }
-  }
-};
+}
 
 int main(int argc, char *argv[]) {
   constexpr const size_t N = 100000;
@@ -56,7 +53,7 @@ int main(int argc, char *argv[]) {
     }
   }
 
-  sycl::queue myQueue{CUDASelector()};
+  sycl::queue myQueue{CUDASelector};
 
   // Command Group creation
   auto cg = [&](sycl::handler &h) {

--- a/examples/vector_addition/vector_addition.cpp
+++ b/examples/vector_addition/vector_addition.cpp
@@ -44,15 +44,11 @@ int main(int argc, char *argv[]) {
     }
   }
 
-  auto CUDASelector = [](sycl::device const &dev)
-  {
-    if (dev.get_platform().get_backend() == sycl::backend::ext_oneapi_cuda)
-    {
+  auto CUDASelector = [](sycl::device const &dev) {
+    if (dev.get_platform().get_backend() == sycl::backend::ext_oneapi_cuda) {
       std::cout << " CUDA device found " << std::endl;
       return 1;
-    }
-    else
-    {
+    } else {
       return -1;
     }
   };

--- a/examples/vector_addition/vector_addition.cpp
+++ b/examples/vector_addition/vector_addition.cpp
@@ -24,15 +24,6 @@
 
 #include <CL/sycl.hpp>
 
-int CUDASelector(sycl::device const & dev){
-  if(dev.get_platform().get_backend() == sycl::backend::ext_oneapi_cuda){
-      std::cout << " CUDA device found " << std::endl;
-      return 1;
-    } else{
-      return -1;
-    }
-}
-
 int main(int argc, char *argv[]) {
   constexpr const size_t N = 100000;
   const sycl::range VecSize{N};
@@ -53,6 +44,18 @@ int main(int argc, char *argv[]) {
     }
   }
 
+  auto CUDASelector = [](sycl::device const &dev)
+  {
+    if (dev.get_platform().get_backend() == sycl::backend::ext_oneapi_cuda)
+    {
+      std::cout << " CUDA device found " << std::endl;
+      return 1;
+    }
+    else
+    {
+      return -1;
+    }
+  };
   sycl::queue myQueue{CUDASelector};
 
   // Command Group creation

--- a/examples/vector_addition/vector_addition_usm.cpp
+++ b/examples/vector_addition/vector_addition_usm.cpp
@@ -24,19 +24,23 @@
 
 #include <CL/sycl.hpp>
 
-int CUDASelector(sycl::device const &dev) {
-  if (dev.get_platform().get_backend() == sycl::backend::ext_oneapi_cuda) {
-    std::cout << " CUDA device found " << std::endl;
-    return 1;
-  } else {
-    return -1;
-  }
-}
 
 int main(int argc, char *argv[]) {
   constexpr const size_t n = 100000;
 
   // Create a sycl queue with our CUDASelector
+  auto CUDASelector = [](sycl::device const &dev)
+  {
+    if (dev.get_platform().get_backend() == sycl::backend::ext_oneapi_cuda)
+    {
+      std::cout << " CUDA device found " << std::endl;
+      return 1;
+    }
+    else
+    {
+      return -1;
+    }
+  };
   sycl::queue myQueue{CUDASelector};
 
   // Host input vectors

--- a/examples/vector_addition/vector_addition_usm.cpp
+++ b/examples/vector_addition/vector_addition_usm.cpp
@@ -24,23 +24,20 @@
 
 #include <CL/sycl.hpp>
 
-class CUDASelector : public sycl::device_selector {
-public:
-  int operator()(const sycl::device &device) const override {
-    if(device.get_platform().get_backend() == sycl::backend::ext_oneapi_cuda){
-      std::cout << " CUDA device found " << std::endl;
-      return 1;
-    } else{
-      return -1;
-    }
+int CUDASelector(sycl::device const &dev) {
+  if (dev.get_platform().get_backend() == sycl::backend::ext_oneapi_cuda) {
+    std::cout << " CUDA device found " << std::endl;
+    return 1;
+  } else {
+    return -1;
   }
-};
+}
 
 int main(int argc, char *argv[]) {
   constexpr const size_t n = 100000;
 
   // Create a sycl queue with our CUDASelector
-  sycl::queue myQueue{CUDASelector()};
+  sycl::queue myQueue{CUDASelector};
 
   // Host input vectors
   double *h_a;

--- a/examples/vector_addition/vector_addition_usm.cpp
+++ b/examples/vector_addition/vector_addition_usm.cpp
@@ -24,20 +24,15 @@
 
 #include <CL/sycl.hpp>
 
-
 int main(int argc, char *argv[]) {
   constexpr const size_t n = 100000;
 
   // Create a sycl queue with our CUDASelector
-  auto CUDASelector = [](sycl::device const &dev)
-  {
-    if (dev.get_platform().get_backend() == sycl::backend::ext_oneapi_cuda)
-    {
+  auto CUDASelector = [](sycl::device const &dev) {
+    if (dev.get_platform().get_backend() == sycl::backend::ext_oneapi_cuda) {
       std::cout << " CUDA device found " << std::endl;
       return 1;
-    }
-    else
-    {
+    } else {
       return -1;
     }
   };


### PR DESCRIPTION
Device selectors as functors are deprecated and replaced with functions taking `sycl::device const &` and returning int. This PR updates the vector addition examples for this change.