### PR TITLE
Enable OpenSSF Scorecard

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,53 @@
+# Scorecards' GitHub action
+
+name: Scorecard supply-chain security
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  schedule:
+    - cron: '7 12 * * 4'
+  push:
+    branches: [ "master" ]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@afb54ba388a7dca6ecae48f608c4ff05ff4cc77a # v3.25.15
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 SYCL for CUDA examples
 ==========================
 
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/codeplaysoftware/SYCL-For-CUDA-Examples/badge)](https://scorecard.dev/viewer/?uri=github.com/codeplaysoftware/SYCL-For-CUDA-Examples)
+
 This repository contains examples that demonstrate how to use the CUDA backend
 in SYCL.
 
@@ -81,3 +83,4 @@ there is no SYCL code in the example, but it includes scripts to build Kokkos wi
 --------------------------------------------
 
 This example is slightly different - it benchmarks a series of hashing algorithms.
+


### PR DESCRIPTION
> Scorecard assesses open source projects for security risks through a series of automated checks.

The following changes will run the OpenSSF scorecard security scan on master branch changes, and periodically on a weekly basis. It will create a report of the project status with recommendations.

We also add the scorecard badge to the README file.