### PR TITLE
Enable dependabot for GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # Enable version updates for Github Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    reviewers:
+      - "codeplaysoftware/security-managers"


### PR DESCRIPTION
The aim of dependency pinning is avoiding supply chain vulnerabilities. OpenSSF scorecard recommends pinning to the actions hash to avoid the situation where a dependency action introduces a vulnerability. Dependabot will check dependencies versions and flag any version with vulnerabilities to be updated.

Dependabot updates will happen once a month. To avoid PR noise to developers, organization level team "security managers" will receive the notification for review.